### PR TITLE
Return none if ipynb module can't be found from find_spec

### DIFF
--- a/notebook_helper/notebook_helper/importer/__init__.py
+++ b/notebook_helper/notebook_helper/importer/__init__.py
@@ -187,7 +187,10 @@ class NotebookFinder(MetaPathFinder):
         return self.loaders[key]
 
     def find_spec(self, fullname, path, target=None):
-        return ModuleSpec(fullname, self.find_module(fullname, path))
+        mod = self.find_module(fullname, path)
+        if mod is None:
+            return mod
+        return ModuleSpec(fullname, mod)
 
     def invalidate_caches(self):
         self.loaders.clear()


### PR DESCRIPTION
The `find_spec` function should return `None` if a module (in this case, loaded from an .ipynb file) can't be found. This allows python's import procedure to go to the next finder in the `sys.meta_path` to try to load the module.

Previously, I assumed that `NotebookFinder` would always be the last element in `sys.meta_path` so that if `NotebookFinder` couldn't find the module, it didn't matter since there was nothing else to look for. However, other libraries may also extend `sys.meta_path` afterwards and so we should not block those libraries from attempting to find modules to load if `NotebookFinder` fails. 

For example, the `six` package also appends to `sys.meta_path` so doing something like:

```py
from notebook_helper import importer
import six
```

will mean that the `NotebookFinder` is now second-to-last in `sys.meta_path` not last.