### PR TITLE
Improve notebook importer error handling

### DIFF
--- a/notebook_helper/AUTHORS.txt
+++ b/notebook_helper/AUTHORS.txt
@@ -1,1 +1,2 @@
+David Liu
 Misha Schwartz

--- a/notebook_helper/README.md
+++ b/notebook_helper/README.md
@@ -11,7 +11,7 @@ pip install 'git+https://github.com/MarkUsProject/autotest-helpers.git#subdirect
 
 ## importer
 
-This allows jupyter notebooks to be imported as python modules. 
+This allows jupyter notebooks to be imported as python modules.
 
 Import the `importer` module first and then import files with an `.ipynb` extension. For example:
 
@@ -45,9 +45,18 @@ for cell in cells:
 importer.run_cells(my_notebook)
 ```
 
+### Handling errors
+
+The `run_cells` and `run` functions take a boolean flag `raise_on_error`, which controls their behaviour if an error is raised when executing a cell.
+
+- If `raise_on_error` is `True` (default), the error is raised from `run_cells` and `run`.
+- If `raise_on_error` is `False`, the error traceback is printed to stderr, but is not re-raised.
+
+Passing `raise_on_error=False` allows partial execution of a notebook's cells (an error is one cell does not necessarily affect the behaviour of another), which can be useful for testing purposes.
+
 ## merger
 
-This provides functions to merge two jupyter notebooks. 
+This provides functions to merge two jupyter notebooks.
 
 The `merge` function returns a notebook created from merging two notebooks: notebook2 into notebook1.
 
@@ -61,7 +70,7 @@ This new notebook will be created by selecting cells from notebook1 and notebook
 3. repeat steps 1 and 2 until all cells in notebook1 have been considered.
 4. if there remain any cells in notebook2 that have not been added to the new notebook, these cells
    appended to the new notebook
-   
+
 The `check` function checks if two notebooks can be merged with the `merge` function (above). It raises an error if either:
 
 - the two notebooks do share any cells with the same ids

--- a/notebook_helper/notebook_helper/importer/__init__.py
+++ b/notebook_helper/notebook_helper/importer/__init__.py
@@ -118,7 +118,11 @@ class CodeCell(Cell):
                 if raise_on_error:
                     raise
                 else:
-                    traceback.print_exception(e)
+                    # First argument is unused (included for backwards compatibility
+                    # with Python 3.9 and earlier)
+                    traceback.print_exception(None, value=e, tb=e.__traceback__)
+                    print('', file=sys.stderr)
+
 
 
 class NotebookModule(types.ModuleType):

--- a/notebook_helper/notebook_helper/test/importer/fixtures/runtime_errors.ipynb
+++ b/notebook_helper/notebook_helper/test/importer/fixtures/runtime_errors.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6920ccbe",
+   "metadata": {},
+   "source": [
+    "This notebook contains two cells, where the first has a runtime error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db8f5c50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "10 + 'hi'  # Raises a TypeError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "97df1cad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 0"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebook_helper/notebook_helper/test/importer/fixtures/syntax_errors.ipynb
+++ b/notebook_helper/notebook_helper/test/importer/fixtures/syntax_errors.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6920ccbe",
+   "metadata": {},
+   "source": [
+    "This notebook contains two cells, where the first has a syntax error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db8f5c50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "10 +"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "97df1cad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = 0"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebook_helper/notebook_helper/test/importer/test_functional.py
+++ b/notebook_helper/notebook_helper/test/importer/test_functional.py
@@ -1,0 +1,45 @@
+import importlib
+import notebook_helper.importer as importer
+import pytest
+
+from fixtures import syntax_errors as _syntax_errors
+from fixtures import runtime_errors as _runtime_errors
+
+@pytest.fixture
+def syntax_errors():
+    return importlib.reload(_syntax_errors)
+
+
+@pytest.fixture
+def runtime_errors():
+    return importlib.reload(_runtime_errors)
+
+
+def test_syntax_errors_raise_on_error(syntax_errors):
+    with pytest.raises(SyntaxError):
+        importer.run_cells(syntax_errors)
+
+
+def test_syntax_errors_no_raise_on_error(syntax_errors):
+    """When raise_on_error=False, the second cell is executed (and x is defined).
+
+    Only the first cell has a syntax error.
+    """
+    importer.run_cells(syntax_errors, raise_on_error=False)
+
+    assert syntax_errors.x == 0
+
+
+def test_runtime_errors_raise_on_error(runtime_errors):
+    with pytest.raises(TypeError):
+        importer.run_cells(runtime_errors)
+
+
+def test_runtime_errors_no_raise_on_error(runtime_errors):
+    """When raise_on_error=False, the second cell is executed (and x is defined).
+
+    Only the first cell has a runtime error.
+    """
+    importer.run_cells(runtime_errors, raise_on_error=False)
+
+    assert runtime_errors.x == 0


### PR DESCRIPTION
Currently when the `notebook_helper.importer` runs cells, there are two issues:

1. Any error that is raised when the cell is run gets propagated upwards, interrupting any subsequent cells from being run. This is consistent with the behaviour when running a Python script, but different than the standard Jupyter notebook user-facing behaviour, where cells are run individually.
2. Syntax errors are reported using the raw text of the notebook file, which is in JSON format, rather than displaying the text of the cell that caused the error. This leads to unhelpful error messages like the following:

    ![image](https://user-images.githubusercontent.com/3333115/156083173-7caac35e-43f6-42b2-a7f1-fa880c1ef3c6.png)

I fixed the first issue by adding an optional argument `raise_on_error` to `importer.run_cells` and `importer.Cell.run` to allow for errors to be suppressed when running cells. I fixed the second by passing a generated "file name" to the `compile` call that's used to run cells; this stops Python from showing the raw text of the notebook file, and instead show the code of the cell.