### PR TITLE
notebook-helper: Make importer load files with UTF-8 encoding

### DIFF
--- a/notebook_helper/notebook_helper/importer/__init__.py
+++ b/notebook_helper/notebook_helper/importer/__init__.py
@@ -175,7 +175,7 @@ class NotebookLoader(Loader):
 
     def exec_module(self, module):
         path = find_notebook(module.__name__, self.path)
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             nb = read(f, as_version=4)
         module.__cells__ = []
         with _user_ns(self.shell, module):


### PR DESCRIPTION
I ran into a text encoding error when loading a Jupyter notebook for testing. I think by default we should be using UTF-8, which is pretty standard in general, but also for the Jupyter notebook ecosystem (https://github.com/jupyter/nbformat/issues/181).

I think it's an open question whether we want this to be configurable in the future, but for now it's a bit urgent to support UTF-8 for reading notebooks.