### PR TITLE
Test validation fixture

### DIFF
--- a/python_helper/README.md
+++ b/python_helper/README.md
@@ -84,11 +84,44 @@ Return a set of the test case names in `testcases` that failed when run.
 - `module_to_replace` is the name of a module to be replaced when running the test case. If this is provided, `module_to_use` must also be provided and should be the *name* of the module that we want to use in place of `function_to_mock`.
 
 #### Usage
-See [test_utils_student_test_helpers.py](./python_helper/test/test_utils_student_test_helpers.py) for more examples.
+See [test_test_case_validation.py](./python_helper/test/test_test_case_validation.py) for more examples.
 
 ```python
 test_cases = get_test_cases(example_tests, allow_pytest=True)
 failures = get_failures(test_cases)
+```
+### make_test_results_fixture(`module`, `function_to_mock`, `functions_to_mock`, `module_to_replace`, `modules_to_use`, `allow_pytest`, `allow_unittest`, `exclusions`)
+Return a fixture that contains the results of the testcases in `module` when replacing the given functions/modules with various others.
+
+The fixture itself returns a ResultsGrid object, composed of ResultsRow objects. These contain information about 1) each test case, and 2) whether the test case passed or failed when run on each of the mocked functions/modules.
+
+#### Usage
+See [test_test_case_validation_fixture.py](./python_helper/test/test_test_case_validation_fixture.py) for more exapmles.
+
+```python
+results_fixture = make_test_results_fixture(example_tests,
+	                                        function_to_mock='fn',
+	                                        functions_to_use=[fn_v1, fn_v2, fn_v3],
+	                                        allow_pytest=True
+	                                        )
+
+def test_example(results_fixture):
+	# len() return the number of test cases discovered
+	assert len(results_fixture) > 0
+
+	# The filter method returns the names of the tests that
+	# fulfill the given criteria
+	filtered_tests = results_fixture.filter(must_pass={'fn_v1'}, must_fail={'fn_v2'})
+	assert len(filtered_tests) > 0
+
+def test_example2(results_fixture):
+	# __getitem__ can be used to get specific tests and mocked functions
+	assert results_fixture['test_the_student_wrote']['fn_v3'] is True
+
+	# Or you can iterate over the results
+	for test_row in results_fixture:
+		assert test_row['fn_v1'] is True
+		assert all(test_result for test_result in test_row)
 ```
 
 ### get_doctest_dict(`function`)

--- a/python_helper/README.md
+++ b/python_helper/README.md
@@ -8,7 +8,7 @@ Helper functions and classes for executing python unit tests.
 pip install git+https://github.com/MarkUsProject/autotest-helpers.git#subdirectory=python_helper
 ```
 
-## Functions
+## General helpers
 ### bound_timeout(`seconds`)
 Return a decorator that will time out the test case after `seconds` seconds. 
 
@@ -21,6 +21,32 @@ def my_function() -> None:
 	...
 ```
 
+### module_fixture(`modname`)
+Return a pytest fixture to import the module modname.
+
+If the module cannot be imported, a detailed error message is raised.
+
+#### Usage
+```python
+my_module = module_fixture('my_module')
+
+def test_student(my_module) -> None:
+    my_module.blah()
+```
+
+### module_lookup(`mod`, `attr`, `attr_type`)
+Return the attribute attr from module mod. If mod does not have attr, an AssertionError is raised.
+
+attr_type is used only to format the error message. Typically 'class' or 'function'.
+
+#### Usage
+```python
+@pytest.fixture(scope="module")
+def MyClass(my_module):
+    return module_lookup(my_module, 'MyClass', 'class')
+```
+
+## Test case validation helpers
 ### get_test_cases(`test_module, allow_pytest=False, allow_unittest=False, test_module_name=''`)
 Return a dictionary mapping the name of test cases in `test_module`
 to a `_CaseWrapper` which can be used to run the tests. `test_module_name` is only required in the case that a module imported into `test_module` needs to be replaced for testing.
@@ -73,6 +99,7 @@ Return a dictionary mapping the doctest examples of `<function>` to their expect
 doctest_examples = get_doctest_dict(function)
 ```
 
+## Code inspection helpers
 ### is_unimplemented(obj_or_path, function_name) -> bool
 Return True if the body of the function `function_name` in the given object
 or path is not implemented (empty). This ignores all comments.

--- a/python_helper/python_helper/__init__.py
+++ b/python_helper/python_helper/__init__.py
@@ -2,3 +2,4 @@ from .timeout import bound_timeout
 from .test_case_validation import get_test_cases, get_failures, get_doctest_dict
 from .code_properties import is_unimplemented, get_recursive, \
     get_functions_using, ASTParser, get_functions_that_call
+from .import_helpers import module_lookup, module_fixture

--- a/python_helper/python_helper/__init__.py
+++ b/python_helper/python_helper/__init__.py
@@ -3,3 +3,4 @@ from .test_case_validation import get_test_cases, get_failures, get_doctest_dict
 from .code_properties import is_unimplemented, get_recursive, \
     get_functions_using, ASTParser, get_functions_that_call
 from .import_helpers import module_lookup, module_fixture
+from .test_case_validation_fixture import make_test_results_fixture

--- a/python_helper/python_helper/import_helpers.py
+++ b/python_helper/python_helper/import_helpers.py
@@ -1,0 +1,34 @@
+import importlib
+import pytest
+from traceback import format_exception_only
+from types import ModuleType
+
+
+def module_fixture(modname: str):
+    """Return a pytest fixture to import the given module."""
+
+    @pytest.fixture(scope="module", name=modname)
+    def submission():
+        f"""The imported module {modname}"""
+        try:
+            mod = importlib.import_module(modname)
+        except Exception as e:
+            msg = f'Could not successfully import {modname}.' \
+                  f'\nDetails:\n\n{"".join(format_exception_only(e))}'
+            raise AssertionError(msg) from e
+        return mod
+
+    submission.__name__ = modname
+
+    return submission
+
+
+def module_lookup(mod: ModuleType, attr: str, attr_type: str):
+    """Wrapper around getattr(mod, attr).
+
+    attr_type is used to format the error message.
+    Typically 'class' or 'function'.
+    """
+    assert hasattr(mod, attr), f'Your {mod.__name__} module did not define a ' \
+                               f'{attr} {attr_type}.'
+    return getattr(mod, attr)

--- a/python_helper/python_helper/test/test_test_case_validation_fixture.py
+++ b/python_helper/python_helper/test/test_test_case_validation_fixture.py
@@ -1,0 +1,117 @@
+import example_tests
+import pytest
+from python_helper.test_case_validation_fixture import make_test_results_fixture
+
+
+def internal_buggy_original(x: int) -> int:
+    """A buggy function.
+    Return 2 * x instead of x.
+    """
+    return 2 * x
+
+
+def buggy_fails_0(x: int) -> int:
+    """A buggy function that only fails when 0 is passed in
+    """
+    if x == 0:
+        return 99
+    return x
+
+
+def correct_function(x: int) -> int:
+    """A buggy function within the same directory as the tests.
+    Return x.
+
+    >>> correct_function(1)
+    1
+    >>> correct_function(2)
+    2
+    >>> correct_function(3) == 3
+    True
+    """
+    return x
+
+
+results = make_test_results_fixture(example_tests,
+                                    function_to_mock='example_tests.internal_buggy',
+                                    functions_to_use=[correct_function,
+                                                      internal_buggy_original,
+                                                      buggy_fails_0
+                                                      ],
+                                    allow_pytest=True,
+                                    allow_unittest=True,
+                                    exclusions={
+                                        'TestUnittests.test_fails_external_buggy',
+                                        'TestUnittests.test_passes_external_buggy',
+                                        'TestPytests.test_fails_external_buggy',
+                                        'TestPytests.test_passes_external_buggy',
+                                        'test_passes_external_parametrize[0]',
+                                        'test_fails_external_buggy',
+                                        'test_passes_external_buggy',
+                                        'test_fails_external_hypothesis',
+                                        'test_fails_external_parametrize[2]',
+                                        'test_fails_external_parametrize[1]'
+                                    }
+                                    )
+
+
+def test_exclusions(results) -> None:
+    """Test that the excluded test names are correctly excluded."""
+    assert not any('external' in result.test_name for result in results)
+    assert len(results) == 10
+
+
+def test_correct_grid(results) -> None:
+    """Test that the grid has the correct results for all test cases.
+    """
+    for test_row in results:
+        assert test_row['correct_function'] is True
+
+        if 'fails' in test_row.test_name:
+            assert test_row['internal_buggy_original'] is False
+
+
+def test_correct_filter_pass_only(results) -> None:
+    """Test that the filter method filters the correct results when given
+    functions that must pass.
+    """
+    filtered_test_names = results.filter(must_pass={'internal_buggy_original'})
+    assert len(filtered_test_names) == 4
+    assert all('passes' in name for name in filtered_test_names)
+
+
+def test_correct_filter_fail_only(results) -> None:
+    """Test that the filter method filters the correct results when given
+    functions that must fail.
+    """
+    filtered_test_names = results.filter(must_fail={'internal_buggy_original'})
+    assert len(filtered_test_names) == 6
+    assert all('fails' in name for name in filtered_test_names)
+
+
+def test_correct_filter(results) -> None:
+    """Test that the filter method filters the correct results when given
+    functions that must pass or fail.
+    """
+    filtered_test_names = results.filter(must_pass={'correct_function'},
+                                         must_fail={'buggy_fails_0'})
+
+    assert filtered_test_names == {'TestPytests.test_passes_internal_buggy',
+                                   'TestUnittests.test_passes_internal_buggy',
+                                   'test_fails_internal_hypothesis',
+                                   'test_passes_internal_buggy',
+                                   'test_passes_internal_parametrize[0]'}
+
+
+def test_correct_filter_exclusions(results) -> None:
+    """Test that the filter method filters the correct results when given
+    functions that must pass or fail, and exclusions.
+    """
+    filtered_test_names = results.filter(must_pass={'correct_function'},
+                                         must_fail={'buggy_fails_0'},
+                                         exclusions={'TestUnittests.test_passes_internal_buggy',
+                                                     'TestPytests.test_passes_internal_buggy'})
+
+    assert filtered_test_names == {'test_fails_internal_hypothesis',
+                                   'test_passes_internal_buggy',
+                                   'test_passes_internal_parametrize[0]'}

--- a/python_helper/python_helper/test_case_validation_fixture.py
+++ b/python_helper/python_helper/test_case_validation_fixture.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+from .test_case_validation import get_test_cases, get_failures
+from typing import Callable
+from types import ModuleType
+import pytest
+
+
+class ResultsGrid:
+    """
+    A collection of test cases and the results of running them when
+    mocked with various functions/modules.
+
+    Attributes:
+    - _mock_names: The names of the mocked functions/modules, in the order
+                   they were originally provided.
+    - _results: A dictionary mapping test case names to their results.
+    """
+    _mock_names: list[str]
+    _results: dict[str, ResultsRow]
+
+    def __init__(self, testcases: dict,
+                 function_to_mock: str = '',
+                 functions_to_use: list[Callable] | None = None,
+                 module_to_replace: str = '',
+                 modules_to_use: list[str] | None = None
+                 ):
+        """Initialize this ResultsGrid."""
+        results = {test_name: {} for test_name in testcases}
+        self._mock_names = []
+
+        if functions_to_use is not None:
+            for fn in functions_to_use:
+                failures = get_failures(testcases,
+                                        function_to_mock=function_to_mock,
+                                        function_to_use=fn)
+
+                for test_name in results:
+                    results[test_name][fn.__name__] = False if test_name in failures else True
+                    self._mock_names.append(fn.__name__)
+
+        if modules_to_use is not None:
+            for mod in modules_to_use:
+                failures = get_failures(testcases,
+                                        module_to_replace=module_to_replace,
+                                        module_to_use=mod)
+
+                for test_name in results:
+                    results[test_name][mod] = False if test_name in failures else True
+                    self._mock_names.append(mod)
+
+        self._results = {test_name: ResultsRow(test_name, results[test_name])
+                         for test_name in results}
+
+    def get_mock_names(self) -> set[str]:
+        """Return a set of names of the modules/functions that were used
+        in generating these results.
+        """
+        return set(self._mock_names)
+
+    def filter(self, must_pass: set[str] = None,
+               must_fail: set[str] = None,
+               exclusions: set[str] = None) -> set[str]:
+        """Return a set of test names that pass on all tests in
+        must_pass, fail on all tests in must_fail, and are not in exclusions.
+        """
+        exclusions = exclusions if exclusions else set()
+        return {test_name for test_name in self._results
+                if test_name not in exclusions and
+                self._results[test_name].matches(must_pass=must_pass,
+                                                 must_fail=must_fail)
+                }
+
+    def __getitem__(self, item):
+        """Return the results for the test case with name item.
+        """
+        return self._results[item]
+
+    def __iter__(self):
+        """Return an iterator that loops through each of the rows
+        in this ResultsGrid.
+        """
+        rows = [self._results[name] for name in self._results]
+        return rows.__iter__()
+
+    def __len__(self):
+        """Return the number of test cases that were tested.
+        """
+        return len(self._results)
+
+
+class ResultsRow:
+    """
+    A row of test case results.
+
+    Attributes:
+    - test_name: The name of the test case
+    - _results: A dictionary mapping the name of the version of the
+                mocked module/function that this test case was run
+                with, to a boolean representing whether the test case
+                passed or failed.
+    """
+    test_name: str
+    _results: dict[str, bool]
+
+    def __init__(self, test_name: str, results: dict[str, bool]):
+        """Initialize this row with the given name and results"""
+        self.test_name = test_name
+        self._results = results
+
+    def matches(self, must_pass: set[str] = None,
+                must_fail: set[str] = None) -> bool:
+        """Return True iff these results pass all tests in must_pass
+        and fails all tests in must_fail.
+        """
+        must_pass = must_pass if must_pass else set()
+        must_fail = must_fail if must_fail else set()
+        return all(self._results[name] is True for name in must_pass) and \
+               all(self._results[name] is False for name in must_fail)
+
+    def __getitem__(self, item) -> bool:
+        """Return whether this result passed or failed when run on item.
+        """
+        if hasattr(item, '__name__'):
+            item = item.__name__
+        return self._results[item]
+
+    def __iter__(self):
+        """Return an iterator for all the (test name, result) pairs"""
+        results = [(name, self._results[name]) for name in self._results]
+        return results.__iter__()
+
+
+def make_test_results_fixture(test_module: ModuleType | Callable,
+                              function_to_mock: str = '',
+                              functions_to_use: list[Callable] | None = None,
+                              module_to_replace: str = '',
+                              modules_to_use: list[str] | None = None,
+                              allow_pytest: bool = False,
+                              allow_unittest: bool = False,
+                              test_module_name: str = '',
+                              exclusions: set[str] = None):
+    """Return a fixture that returns the results of running the tests in
+    test_module with the various versions of functions/modules provided.
+    """
+
+    @pytest.fixture(scope="module")
+    def results():
+        test_cases = get_test_cases(test_module, allow_pytest=allow_pytest,
+                                    allow_unittest=allow_unittest,
+                                    test_module_name=test_module_name
+                                    )
+        if exclusions:
+            for exclusion in exclusions:
+                test_cases.pop(exclusion)
+        test_results = ResultsGrid(test_cases,
+                                   function_to_mock=function_to_mock,
+                                   functions_to_use=functions_to_use,
+                                   module_to_replace=module_to_replace,
+                                   modules_to_use=modules_to_use
+                                   )
+        return test_results
+
+    return results


### PR DESCRIPTION
Adding `make_test_results_fixture`, which returns a grid of results mapping test cases to whether they pass or fail when run on various mocked functions/modules.

### Usage

```python
results_fixture = make_test_results_fixture(example_tests,
	                                        function_to_mock='fn',
	                                        functions_to_use=[fn_v1, fn_v2, fn_v3],
	                                        allow_pytest=True
	                                        )

def test_example(results_fixture):
	# len() return the number of test cases discovered
	assert len(results_fixture) > 0

	# The filter method returns the names of the tests that
	# fulfill the given criteria
	filtered_tests = results_fixture.filter(must_pass={'fn_v1'}, must_fail={'fn_v2'})
	assert len(filtered_tests) > 0

def test_example2(results_fixture):
	# __getitem__ can be used to get specific tests and mocked functions
	assert results_fixture['test_the_student_wrote']['fn_v3'] is True

	# Or you can iterate over the results
	for test_row in results_fixture:
		assert test_row['fn_v1'] is True
		assert all(test_result for test_result in test_row)
```